### PR TITLE
Connect frontend calculator UI to backend REST API with text evaluation endpoint

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -25,6 +25,9 @@ jobs:
     - id: checkout
       name: checkout repository
       uses: actions/checkout@v6
+      with:
+        ref: ${{ github.ref_name }}
+        fetch-depth: 0
       
     - id: setupjava
       name: Set up with Java 25
@@ -57,10 +60,11 @@ jobs:
         echo "branch coverage = ${{ steps.jacoco.outputs.branches }}"
 
     - name: Commit and push coverage badges
+      if: ${{ github.event_name == 'push' && github.actor != 'github-actions[bot]' }}
       uses: EndBug/add-and-commit@a94899bca583c204427a224a7af87c02f9b325d5 # v9.1.4
       with:
         default_author: github_actions
-        message: 'chore(ci): update coverage badges'
+        message: 'chore(ci): update coverage badges [skip ci]'
         add: '.github/badges/*.svg .github/badges/*.json'
 
 #    - name: Commit and push the svg badges and the json coverage summary (if it changed)

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -26,7 +26,6 @@ jobs:
       name: checkout repository
       uses: actions/checkout@v6
       with:
-        ref: ${{ github.ref_name }}
         fetch-depth: 0
       
     - id: setupjava

--- a/src/main/java/calculator/api/TextEvaluationRequest.java
+++ b/src/main/java/calculator/api/TextEvaluationRequest.java
@@ -1,0 +1,20 @@
+package calculator.api;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TextEvaluationRequest {
+
+    @NotBlank(message = "expression must not be blank")
+    private String expression;
+
+    public TextEvaluationRequest() {
+    }
+
+    public TextEvaluationRequest(String expression) {
+        this.expression = expression;
+    }
+}

--- a/src/main/java/calculator/api/TextEvaluationResponse.java
+++ b/src/main/java/calculator/api/TextEvaluationResponse.java
@@ -1,0 +1,24 @@
+package calculator.api;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class TextEvaluationResponse {
+
+    private String result;
+    private String infix;
+    private String pretty;
+    private String prefix;
+
+    public TextEvaluationResponse() {
+    }
+
+    public TextEvaluationResponse(String result, String infix, String pretty, String prefix) {
+        this.result = result;
+        this.infix = infix;
+        this.pretty = pretty;
+        this.prefix = prefix;
+    }
+}

--- a/src/main/java/calculator/api/config/RequestSizeLimitFilter.java
+++ b/src/main/java/calculator/api/config/RequestSizeLimitFilter.java
@@ -40,8 +40,11 @@ public class RequestSizeLimitFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        // For now I only apply this protection to the evaluation endpoint.
-        return !"/api/evaluate".equals(request.getRequestURI()) || !"POST".equalsIgnoreCase(request.getMethod());
+        if (!"POST".equalsIgnoreCase(request.getMethod())) {
+            return true;
+        }
+        String uri = request.getRequestURI();
+        return !"/api/evaluate".equals(uri) && !"/api/evaluate-text".equals(uri);
     }
 
     private void writePayloadTooLargeResponse(

--- a/src/main/java/calculator/api/controller/CalculatorApiController.java
+++ b/src/main/java/calculator/api/controller/CalculatorApiController.java
@@ -2,6 +2,8 @@ package calculator.api.controller;
 
 import calculator.api.EvaluationResponse;
 import calculator.api.ExpressionRequest;
+import calculator.api.TextEvaluationRequest;
+import calculator.api.TextEvaluationResponse;
 import calculator.api.service.CalculatorApiService;
 import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
@@ -28,5 +30,11 @@ public class CalculatorApiController {
     @GetMapping("/health")
     public Map<String, String> health() {
         return Map.of("status", "UP");
+    }
+
+    // REST endpoint used by the GUI to evaluate a textual expression.
+    @PostMapping("/evaluate-text")
+    public TextEvaluationResponse evaluateText(@Valid @RequestBody TextEvaluationRequest request) {
+        return calculatorApiService.evaluateText(request.getExpression());
     }
 }

--- a/src/main/java/calculator/api/service/CalculatorApiService.java
+++ b/src/main/java/calculator/api/service/CalculatorApiService.java
@@ -3,10 +3,12 @@ package calculator.api.service;
 
 import calculator.Calculator;
 import calculator.Expression;
+import calculator.ExpressionParser;
 import calculator.Notation;
 import calculator.api.EvaluationResponse;
 import calculator.api.ExpressionMapper;
 import calculator.api.ExpressionRequest;
+import calculator.api.TextEvaluationResponse;
 import calculator.numbers.BaseNumber;
 import calculator.numbers.IntegerNumber;
 import org.springframework.stereotype.Service;
@@ -25,10 +27,12 @@ public class CalculatorApiService {
 
     private final Calculator calculator;
     private final ExpressionMapper expressionMapper;
+    private final ExpressionParser expressionParser;
 
     public CalculatorApiService(ExpressionMapper expressionMapper) {
         this.calculator = new Calculator();
         this.expressionMapper = Objects.requireNonNull(expressionMapper, "expressionMapper must not be null");
+        this.expressionParser = new ExpressionParser();
     }
 
     // This method connects the API layer to the calculator core.
@@ -45,5 +49,29 @@ public class CalculatorApiService {
         response.setPretty(calculator.prettyFormat(expression));
         response.setPrefix(calculator.format(expression, Notation.PREFIX));
         return response;
+    }
+
+    public TextEvaluationResponse evaluateText(String rawExpression) {
+        if (rawExpression == null || rawExpression.isBlank()) {
+            throw new IllegalArgumentException("Expression text must not be blank.");
+        }
+
+        String normalizedExpression = normalizeExpression(rawExpression);
+        try {
+            Expression expression = expressionParser.parse(normalizedExpression);
+            BaseNumber evaluated = calculator.eval(expression);
+            TextEvaluationResponse response = new TextEvaluationResponse();
+            response.setResult(evaluated.toString());
+            response.setInfix(calculator.format(expression, Notation.INFIX));
+            response.setPretty(calculator.prettyFormat(expression));
+            response.setPrefix(calculator.format(expression, Notation.PREFIX));
+            return response;
+        } catch (RuntimeException exception) {
+            throw new IllegalArgumentException("Invalid expression syntax.");
+        }
+    }
+
+    private String normalizeExpression(String expression) {
+        return expression.replace("^", "**").trim();
     }
 }

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -5,7 +5,10 @@ createApp({
     return {
       expression: "",
       isScienceMenuOpen: false,
-      hintMessage: "No calculation is done in this GUI."
+      hintMessage: "Ready.",
+      result: "",
+      resultPretty: "",
+      isLoading: false
     };
   },
   mounted() {
@@ -20,8 +23,12 @@ createApp({
     },
 
     appendToken(token) {
+      if (token === "=") {
+        this.evaluateExpression();
+        return;
+      }
       this.expression += token;
-      this.hintMessage = "Expression captured only (frontend demo).";
+      this.hintMessage = "Expression updated.";
     },
 
     appendScientificToken(token) {
@@ -43,7 +50,7 @@ createApp({
 
       if (event.key === "Enter") {
         event.preventDefault();
-       
+        this.evaluateExpression();
         return;
       }
 
@@ -61,6 +68,8 @@ createApp({
 
     clearExpression() {
       this.expression = "";
+      this.result = "";
+      this.resultPretty = "";
       this.hintMessage = "Expression cleared.";
     },
 
@@ -70,7 +79,66 @@ createApp({
       }
 
       this.expression = this.expression.slice(0, -1);
-      this.hintMessage = "Expression captured only (frontend demo).";
+      this.hintMessage = "Expression updated.";
+    },
+
+    async evaluateExpression() {
+      if (this.isLoading) {
+        return;
+      }
+
+      const expression = this.expression.trim();
+      if (!expression) {
+        this.result = "";
+        this.resultPretty = "";
+        this.hintMessage = "Enter an expression first.";
+        return;
+      }
+
+      this.isLoading = true;
+      this.hintMessage = "Calculating...";
+
+      try {
+        const response = await fetch("/api/evaluate-text", {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json"
+          },
+          body: JSON.stringify({ expression: this.normalizeExpression(expression) })
+        });
+
+        const payload = await response.json();
+        if (!response.ok) {
+          this.result = "";
+          this.resultPretty = "";
+          this.hintMessage = this.formatApiError(payload);
+          return;
+        }
+
+        this.result = payload.result ?? "";
+        this.resultPretty = payload.pretty ?? "";
+        this.hintMessage = "Calculation done.";
+      } catch (_) {
+        this.result = "";
+        this.resultPretty = "";
+        this.hintMessage = "Unable to reach the API.";
+      } finally {
+        this.isLoading = false;
+      }
+    },
+
+    normalizeExpression(expression) {
+      return expression.replace(/\^/g, "**");
+    },
+
+    formatApiError(payload) {
+      if (!payload || typeof payload !== "object") {
+        return "Request failed.";
+      }
+      if (Array.isArray(payload.details) && payload.details.length > 0) {
+        return payload.details[0];
+      }
+      return payload.message || "Request failed.";
     }
   }
 }).mount("#app");

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -83,7 +83,13 @@
           <button type="button" @click="appendToken('.')">.</button>
           <button type="button" class="op" @click="appendToken('+')">+</button>
 
-          <button type="button" class="ghost" @click="appendToken('=')">=</button>
+          <button type="button" class="ghost" @click="evaluateExpression">=</button>
+        </section>
+
+        <section class="output" aria-live="polite">
+          <p class="hint">{{ hintMessage }}</p>
+          <p v-if="result" class="hint">Result: {{ result }}</p>
+          <p v-if="resultPretty" class="hint">Pretty: {{ resultPretty }}</p>
         </section>
       </main>
     </div>

--- a/src/test/java/calculator/api/config/TestRequestSizeLimitFilter.java
+++ b/src/test/java/calculator/api/config/TestRequestSizeLimitFilter.java
@@ -58,6 +58,21 @@ class TestRequestSizeLimitFilter {
     }
 
     @Test
+    void testRejectsTooLargeEvaluateTextPayload() throws Exception {
+        RequestSizeLimitFilter filter = new RequestSizeLimitFilter(8);
+        MockHttpServletRequest request = new MockHttpServletRequest("POST", "/api/evaluate-text");
+        request.setContent("123456789".getBytes(StandardCharsets.UTF_8));
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        MockFilterChain chain = new MockFilterChain();
+
+        filter.doFilter(request, response, chain);
+
+        assertEquals(413, response.getStatus());
+        assertTrue(response.getContentAsString().contains("\"code\":\"REQUEST_TOO_LARGE\""));
+        assertNull(chain.getRequest());
+    }
+
+    @Test
     void testSkipsFilterForNonPostMethod() throws Exception {
         RequestSizeLimitFilter filter = new RequestSizeLimitFilter(1);
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/api/evaluate");

--- a/src/test/java/calculator/api/controller/TestCalculatorApiController.java
+++ b/src/test/java/calculator/api/controller/TestCalculatorApiController.java
@@ -227,4 +227,55 @@ class TestCalculatorApiController {
                 .andExpect(status().isPayloadTooLarge())
                 .andExpect(jsonPath("$.code").value("REQUEST_TOO_LARGE"));
     }
+
+    @Test
+    void testEvaluateTextEndpoint() throws Exception {
+        String payload = """
+                {
+                  "expression": "(3+4)*5"
+                }
+                """;
+
+        mockMvc.perform(post("/api/evaluate-text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.result").value("35"))
+                .andExpect(jsonPath("$.infix").exists())
+                .andExpect(jsonPath("$.pretty").exists())
+                .andExpect(jsonPath("$.prefix").exists());
+    }
+
+    @Test
+    void testEvaluateTextEndpointRejectsBlankExpression() throws Exception {
+        String payload = """
+                {
+                  "expression": "   "
+                }
+                """;
+
+        mockMvc.perform(post("/api/evaluate-text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("VALIDATION_ERROR"))
+                .andExpect(jsonPath("$.details", hasItem("expression: expression must not be blank")));
+    }
+
+    @Test
+    void testEvaluateTextEndpointRejectsInvalidSyntax() throws Exception {
+        String payload = """
+                {
+                  "expression": "3++"
+                }
+                """;
+
+        mockMvc.perform(post("/api/evaluate-text")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value("INVALID_REQUEST"))
+                .andExpect(jsonPath("$.message").value("Invalid expression syntax."));
+    }
 }


### PR DESCRIPTION
**Description**
This PR connects the Vue frontend to the Spring Boot backend so the calculator performs real server-side evaluations through REST.
It introduces a new **_POST /api/evaluate-text_** endpoint that accepts a text expression, parses it on the backend, evaluates it, and returns result, infix, pretty, and prefix representations. The frontend now calls this endpoint on = and Enter, and displays both computed results and API error messages.
It also extends the request-size protection filter to cover **_POST /api/evaluate-text_** and adds controller/filter tests for the new behavior (success, validation error, invalid syntax, and payload-size handling). API-focused test runs pass in this environment.