### PR TITLE
Fix/alwaysdata deployment

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -14,6 +14,7 @@ permissions:
 
 jobs:
   dependency-review:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest,macos-latest]

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -54,7 +54,7 @@ jobs:
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 
-      - name: Stop legacy manual Java process
+      - name: Sync runtime jar paths and restart app
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.ALWAYSDATA_HOST }}
@@ -66,7 +66,15 @@ jobs:
           script: |
             cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
             chmod +x start-alwaysdata.sh
+            mkdir -p target
+            LEGACY_JAR="$(find target -maxdepth 1 -type f -name '*.jar' | head -n 1 || true)"
+            if [ -n "${LEGACY_JAR:-}" ]; then
+              cp app.jar "$LEGACY_JAR"
+            else
+              cp app.jar target/calculator-cucumber-0.5.0.jar
+            fi
             PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*calculator-cucumber-0\.5\.0\.jar/ || /[j]ava .* -jar .*app\.jar/ {print $1}')"
             if [ -n "$PIDS" ]; then
               kill $PIDS || true
             fi
+            nohup ./start-alwaysdata.sh > app.log 2>&1 &

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -54,7 +54,7 @@ jobs:
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 
-      - name: Restart application on Alwaysdata
+      - name: Stop legacy manual Java process
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.ALWAYSDATA_HOST }}
@@ -66,8 +66,7 @@ jobs:
           script: |
             cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
             chmod +x start-alwaysdata.sh
-            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*app\.jar/ || /[j]ava .* -jar .*target\/.*\.jar/ {print $1}')"
+            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*calculator-cucumber-0\.5\.0\.jar/ || /[j]ava .* -jar .*app\.jar/ {print $1}')"
             if [ -n "$PIDS" ]; then
               kill $PIDS || true
             fi
-            nohup ./start-alwaysdata.sh > app.log 2>&1 &

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -69,20 +69,16 @@ jobs:
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 
-      - name: Restart app
-        uses: appleboy/ssh-action@v1.2.0
-        with:
-          host: ${{ secrets.ALWAYSDATA_HOST }}
-          username: ${{ secrets.ALWAYSDATA_USER }}
-          key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
-          password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
-          port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
-          script_stop: true
-          script: |
-            cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
-            chmod +x start-alwaysdata.sh
-            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*calculator-cucumber-0\.5\.0\.jar/ || /[j]ava .* -jar .*app\.jar/ {print $1}')"
-            if [ -n "$PIDS" ]; then
-              kill $PIDS || true
-            fi
-            nohup ./start-alwaysdata.sh > app.log 2>&1 &
+      - name: Restart site via Alwaysdata API
+        env:
+          ALWAYSDATA_API_KEY: ${{ secrets.ALWAYSDATA_API_KEY }}
+          ALWAYSDATA_ACCOUNT: ${{ secrets.ALWAYSDATA_ACCOUNT }}
+          ALWAYSDATA_SITE_ID: ${{ secrets.ALWAYSDATA_SITE_ID }}
+        run: |
+          curl --fail --show-error --silent \
+            -X POST \
+            -H "alwaysdata-synchronous: yes" \
+            --basic \
+            --user "${ALWAYSDATA_API_KEY} account=${ALWAYSDATA_ACCOUNT}:" \
+            "https://api.alwaysdata.com/v1/site/${ALWAYSDATA_SITE_ID}/restart/" \
+            >/dev/null

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -66,7 +66,7 @@ jobs:
           script: |
             cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
             chmod +x start-alwaysdata.sh
-            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar app\.jar/ {print $1}')"
+            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*app\.jar/ || /[j]ava .* -jar .*target\/.*\.jar/ {print $1}')"
             if [ -n "$PIDS" ]; then
               kill $PIDS || true
             fi

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -66,5 +66,8 @@ jobs:
           script: |
             cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
             chmod +x start-alwaysdata.sh
-            pkill -f 'java -jar app.jar' || true
+            PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar app\.jar/ {print $1}')"
+            if [ -n "$PIDS" ]; then
+              kill $PIDS || true
+            fi
             nohup ./start-alwaysdata.sh > app.log 2>&1 &

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -1,0 +1,68 @@
+name: Deploy to Alwaysdata
+
+on:
+  push:
+    branches:
+      - master
+      - fix/alwaysdata-deployment
+
+concurrency:
+  group: alwaysdata-production
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build and deploy to Alwaysdata
+    runs-on: ubuntu-latest
+    environment: production
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 25
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "25"
+          cache: maven
+
+      - name: Build application
+        run: mvn -B package --file pom.xml
+
+      - name: Prepare deployment bundle
+        run: |
+          mkdir -p deploy
+          JAR_PATH="$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)"
+          if [ -z "${JAR_PATH:-}" ]; then
+            echo "No executable jar found in target/"
+            exit 1
+          fi
+          cp "$JAR_PATH" deploy/app.jar
+          cp start-alwaysdata.sh deploy/start-alwaysdata.sh
+          chmod +x deploy/start-alwaysdata.sh
+
+      - name: Upload bundle to Alwaysdata
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.ALWAYSDATA_HOST }}
+          username: ${{ secrets.ALWAYSDATA_USER }}
+          key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
+          port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
+          source: "deploy/*"
+          target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
+          strip_components: 1
+
+      - name: Restart application on Alwaysdata
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.ALWAYSDATA_HOST }}
+          username: ${{ secrets.ALWAYSDATA_USER }}
+          key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
+          port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
+          script_stop: true
+          script: |
+            cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
+            chmod +x start-alwaysdata.sh
+            pkill -f 'java -jar app.jar' || true
+            nohup ./start-alwaysdata.sh > app.log 2>&1 &

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -48,6 +48,7 @@ jobs:
           host: ${{ secrets.ALWAYSDATA_HOST }}
           username: ${{ secrets.ALWAYSDATA_USER }}
           key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
+          password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
           port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
           source: "deploy/*"
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
@@ -59,6 +60,7 @@ jobs:
           host: ${{ secrets.ALWAYSDATA_HOST }}
           username: ${{ secrets.ALWAYSDATA_USER }}
           key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
+          password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
           port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
           script_stop: true
           script: |

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -42,6 +42,21 @@ jobs:
           cp start-alwaysdata.sh deploy/start-alwaysdata.sh
           chmod +x deploy/start-alwaysdata.sh
 
+      - name: Free space on Alwaysdata before upload
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.ALWAYSDATA_HOST }}
+          username: ${{ secrets.ALWAYSDATA_USER }}
+          key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
+          password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
+          port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
+          script_stop: true
+          script: |
+            cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
+            rm -f ./*.tar.gz ./app.jar
+            rm -rf ./target
+            rm -f ./app.log
+
       - name: Upload bundle to Alwaysdata
         uses: appleboy/scp-action@v0.1.7
         with:
@@ -54,7 +69,7 @@ jobs:
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 
-      - name: Sync runtime jar paths and restart app
+      - name: Restart app
         uses: appleboy/ssh-action@v1.2.0
         with:
           host: ${{ secrets.ALWAYSDATA_HOST }}
@@ -66,13 +81,6 @@ jobs:
           script: |
             cd "${{ secrets.ALWAYSDATA_DEPLOY_PATH }}"
             chmod +x start-alwaysdata.sh
-            mkdir -p target
-            LEGACY_JAR="$(find target -maxdepth 1 -type f -name '*.jar' | head -n 1 || true)"
-            if [ -n "${LEGACY_JAR:-}" ]; then
-              cp app.jar "$LEGACY_JAR"
-            else
-              cp app.jar target/calculator-cucumber-0.5.0.jar
-            fi
             PIDS="$(ps -eo pid=,args= | awk '/[j]ava .* -jar .*calculator-cucumber-0\.5\.0\.jar/ || /[j]ava .* -jar .*app\.jar/ {print $1}')"
             if [ -n "$PIDS" ]; then
               kill $PIDS || true

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Prepare deployment bundle
         run: |
-          mkdir -p deploy/target
+          mkdir -p deploy
           JAR_PATH="$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)"
           if [ -z "${JAR_PATH:-}" ]; then
             echo "No executable jar found in target/"
             exit 1
           fi
-          cp "$JAR_PATH" deploy/target/
+          cp "$JAR_PATH" deploy/app.jar
           cp start-alwaysdata.sh deploy/start-alwaysdata.sh
           chmod +x deploy/start-alwaysdata.sh
 
@@ -50,7 +50,7 @@ jobs:
           key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
           password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
           port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
-          source: "deploy/start-alwaysdata.sh,deploy/target/*.jar"
+          source: "deploy/*"
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 

--- a/.github/workflows/deploy-alwaysdata.yml
+++ b/.github/workflows/deploy-alwaysdata.yml
@@ -32,13 +32,13 @@ jobs:
 
       - name: Prepare deployment bundle
         run: |
-          mkdir -p deploy
+          mkdir -p deploy/target
           JAR_PATH="$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)"
           if [ -z "${JAR_PATH:-}" ]; then
             echo "No executable jar found in target/"
             exit 1
           fi
-          cp "$JAR_PATH" deploy/app.jar
+          cp "$JAR_PATH" deploy/target/
           cp start-alwaysdata.sh deploy/start-alwaysdata.sh
           chmod +x deploy/start-alwaysdata.sh
 
@@ -50,7 +50,7 @@ jobs:
           key: ${{ secrets.ALWAYSDATA_SSH_KEY }}
           password: ${{ secrets.ALWAYSDATA_SSH_PASSWORD }}
           port: ${{ secrets.ALWAYSDATA_SSH_PORT != '' && secrets.ALWAYSDATA_SSH_PORT || '22' }}
-          source: "deploy/*"
+          source: "deploy/start-alwaysdata.sh,deploy/target/*.jar"
           target: ${{ secrets.ALWAYSDATA_DEPLOY_PATH }}
           strip_components: 1
 

--- a/pom.xml
+++ b/pom.xml
@@ -152,6 +152,13 @@
                 <configuration>
                     <mainClass>calculator.api.ApiApplication</mainClass>
                 </configuration>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>repackage</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
 
             <plugin>

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,5 +1,5 @@
 calculator.api.max-expression-depth=20
 calculator.api.max-operation-args=20
 calculator.api.max-request-size-bytes=8192
-calculator.api.cors.allowed-origins=http://localhost:3000,http://127.0.0.1:3000
+calculator.api.cors.allowed-origins=http://localhost:3000,http://127.0.0.1:3000,http://hakik.alwaysdata.net,https://hakik.alwaysdata.net
 spring.jackson.deserialization.fail-on-unknown-properties=true

--- a/src/main/resources/static/app.js
+++ b/src/main/resources/static/app.js
@@ -107,7 +107,7 @@ createApp({
           body: JSON.stringify({ expression: this.normalizeExpression(expression) })
         });
 
-        const payload = await response.json();
+        const payload = await this.readApiPayload(response);
         if (!response.ok) {
           this.result = "";
           this.resultPretty = "";
@@ -138,7 +138,23 @@ createApp({
       if (Array.isArray(payload.details) && payload.details.length > 0) {
         return payload.details[0];
       }
+      if (payload.rawText) {
+        return payload.rawText;
+      }
       return payload.message || "Request failed.";
+    },
+
+    async readApiPayload(response) {
+      const contentType = response.headers.get("content-type") || "";
+      if (contentType.includes("application/json")) {
+        return response.json();
+      }
+
+      const rawText = await response.text();
+      return {
+        message: response.ok ? "Unexpected response format." : `HTTP ${response.status}`,
+        rawText: rawText ? rawText.slice(0, 200) : ""
+      };
     }
   }
 }).mount("#app");

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,6 +15,7 @@
   <body>
     <div id="app" class="page">
       <main class="calculator-card with-drawer" :class="{ open: isScienceMenuOpen }">
+        <p class="deploy-flag">Deploy test: fix/alwaysdata-deployment</p>
         <button
           type="button"
           class="science-toggle"

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,6 +15,7 @@
   <body>
     <div id="app" class="page">
       <main class="calculator-card with-drawer" :class="{ open: isScienceMenuOpen }">
+        <p class="deploy-flag">Deploy test 2: fix/alwaysdata-deployment</p>
         <button
           type="button"
           class="science-toggle"

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css" />
+    <link rel="stylesheet" href="style.css?v=3" />
   </head>
   <body>
     <div id="app" class="page">
@@ -95,6 +95,6 @@
     </div>
 
     <script src="https://unpkg.com/vue@3/dist/vue.global.prod.js"></script>
-    <script src="app.js"></script>
+    <script src="app.js?v=3"></script>
   </body>
 </html>

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,7 +15,6 @@
   <body>
     <div id="app" class="page">
       <main class="calculator-card with-drawer" :class="{ open: isScienceMenuOpen }">
-        <p class="deploy-flag">Deploy test: fix/alwaysdata-deployment</p>
         <button
           type="button"
           class="science-toggle"

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,7 +15,7 @@
   <body>
     <div id="app" class="page">
       <main class="calculator-card with-drawer" :class="{ open: isScienceMenuOpen }">
-        <p class="deploy-flag">Deploy test 2: fix/alwaysdata-deployment</p>
+        <p class="deploy-flag">Deploy test 3: auto-restart via API</p>
         <button
           type="button"
           class="science-toggle"

--- a/src/main/resources/static/index.html
+++ b/src/main/resources/static/index.html
@@ -15,7 +15,6 @@
   <body>
     <div id="app" class="page">
       <main class="calculator-card with-drawer" :class="{ open: isScienceMenuOpen }">
-        <p class="deploy-flag">Deploy test 3: auto-restart via API</p>
         <button
           type="button"
           class="science-toggle"

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -42,6 +42,15 @@ body {
   animation: rise 0.55s ease-out;
 }
 
+.deploy-flag {
+  margin: 0 0 0.65rem;
+  font-size: 0.78rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: #355f7d;
+  font-weight: 700;
+}
+
 .with-drawer {
   overflow: visible;
 }

--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -42,15 +42,6 @@ body {
   animation: rise 0.55s ease-out;
 }
 
-.deploy-flag {
-  margin: 0 0 0.65rem;
-  font-size: 0.78rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: #355f7d;
-  font-weight: 700;
-}
-
 .with-drawer {
   overflow: visible;
 }

--- a/start-alwaysdata.sh
+++ b/start-alwaysdata.sh
@@ -4,10 +4,14 @@ set -eu
 
 export JAVA_VERSION="${JAVA_VERSION:-25}"
 
-JAR_PATH=$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)
+if [ -f "./app.jar" ]; then
+    JAR_PATH="./app.jar"
+else
+    JAR_PATH=$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)
+fi
 
 if [ -z "${JAR_PATH:-}" ]; then
-    echo "No executable jar found in target/. Run mvn package first." >&2
+    echo "No executable jar found (expected ./app.jar or target/*.jar)." >&2
     exit 1
 fi
 

--- a/start-alwaysdata.sh
+++ b/start-alwaysdata.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+set -eu
+
+export JAVA_VERSION="${JAVA_VERSION:-25}"
+
+JAR_PATH=$(find target -maxdepth 1 -type f -name '*.jar' ! -name '*.original' | head -n 1)
+
+if [ -z "${JAR_PATH:-}" ]; then
+    echo "No executable jar found in target/. Run mvn package first." >&2
+    exit 1
+fi
+
+exec java -jar "$JAR_PATH" --server.address="${IP:-::}" --server.port="${PORT:-8080}"


### PR DESCRIPTION
**Description de PR :**
This PR fixes the production deployment on Alwaysdata for the Spring Boot calculator application.
It adds the Spring Boot repackage goal so Maven produces an executable jar, introduces a start-alwaysdata.sh startup script for Alwaysdata user-program hosting, and updates the runtime launch to use the platform-provided IP and PORT while forcing Java 25. It also fixes production frontend behavior by improving API error handling, busting cached static assets, and allowing the Alwaysdata domain in the CORS configuration so HTTPS requests to the API are accepted.