### PR TITLE
Update release reports only on ubuntu-latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           generate-summary: true
 
       - name: Bundle Reports for Release
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (matrix.os == 'ubuntu-latest')
         run: |
           mkdir -p release-assets
           cp -r target/reports/apidocs release-assets/javadoc
@@ -58,7 +58,7 @@ jobs:
           zip -r project-reports.zip release-assets
 
       - name: Create Release and Upload Assets
-        if: startsWith(github.ref, 'refs/tags/')
+        if: startsWith(github.ref, 'refs/tags/') && (matrix.os == 'ubuntu-latest')
         uses: softprops/action-gh-release@v2
         with:
           files: |
@@ -69,9 +69,9 @@ jobs:
 
       - name: Upload Artifacts
         uses: actions/upload-artifact@v4
-        if: always()
+        if: matrix.os == 'ubuntu-latest'
         with:
-          name: full-reports-pack-${{ matrix.os }}
+          name: full-reports-pack
           path: |
             target/site/jacoco/
             target/reports/apidocs/

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -17,6 +17,8 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest,macos-latest]
+
+    runs-on: ${{ matrix.os }}
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6


### PR DESCRIPTION
# Summary
- Windows does not support .zip so emitted an error on release  
- runs-on was missing in depedency-review.yml 
# Fix
Ubuntu-latest generates the report